### PR TITLE
Enable injecting location in builder

### DIFF
--- a/src/MLIR/AST/Builder.hs
+++ b/src/MLIR/AST/Builder.hs
@@ -79,7 +79,7 @@ freshBlockArg ty = (("arg" <>) <$> freshName) <&> (:> ty)
 data BlockBindings = BlockBindings
   { blockBindings :: SnocList Binding
   , blockArguments :: SnocList Value
-  , blockLocation :: Location
+  , blockDefaultLocation :: Location
   }
 
 instance Semigroup BlockBindings where
@@ -103,7 +103,7 @@ class Monad m => MonadBlockDecl m where
 class MonadBlockDecl m => MonadBlockBuilder m where
   emitOp :: Operation -> m [Value]
   blockArgument :: Type -> m Value
-  setLocation :: Location -> m ()
+  setDefaultLocation :: Location -> m ()
 
 data EndOfBlock = EndOfBlock
 
@@ -127,7 +127,7 @@ instance Monad m => MonadBlockDecl (BlockBuilderT m) where
 
 instance MonadNameSupply m => MonadBlockBuilder (BlockBuilderT m) where
   emitOp opNoLoc = BlockBuilderT $ do
-    loc <- gets blockLocation
+    loc <- gets blockDefaultLocation
     let op = case opLocation opNoLoc of
           UnknownLocation -> opNoLoc { opLocation = loc }
           _ -> opNoLoc
@@ -140,7 +140,7 @@ instance MonadNameSupply m => MonadBlockBuilder (BlockBuilderT m) where
     value <- lift $ freshValue ty
     modify \s -> s { blockArguments = blockArguments s .:. value }
     return value
-  setLocation loc = BlockBuilderT $ modify \s -> s { blockLocation = loc }
+  setDefaultLocation loc = BlockBuilderT $ modify \s -> s { blockDefaultLocation = loc }
 
 --------------------------------------------------------------------------------
 -- Region builder monad

--- a/src/MLIR/AST/Builder.hs
+++ b/src/MLIR/AST/Builder.hs
@@ -115,7 +115,7 @@ noTerminator = return EndOfBlock
 
 runBlockBuilder :: Monad m => BlockBuilderT m a -> m (a, ([Value], [Binding]))
 runBlockBuilder (BlockBuilderT act) = do
-  (result, BlockBindings binds args loc) <- runStateT act mempty
+  (result, BlockBindings binds args _) <- runStateT act mempty
   return (result, (unsnocList args, unsnocList binds))
 
 instance Monad m => MonadBlockDecl (BlockBuilderT m) where

--- a/test/MLIR/BuilderSpec.hs
+++ b/test/MLIR/BuilderSpec.hs
@@ -21,6 +21,7 @@ import Control.Monad.Identity
 import MLIR.AST
 import MLIR.AST.Builder
 import MLIR.AST.Serialize
+import qualified Data.ByteString as BS
 import qualified MLIR.AST.Dialect.Std as Std
 import qualified MLIR.Native as MLIR
 
@@ -75,6 +76,31 @@ spec = do
                     Std.return [result]
                   endOfRegion
       verifyAndDump m
+
+  it "location propagation in builder" $ do
+      let f32 = Float32Type
+      let m = runIdentity $ buildModule $ do
+                buildSimpleFunction "f_loc" [f32] NoAttrs do
+                  x <- blockArgument f32
+                  y <- Std.addf x x
+                  setLocation (FileLocation "file.mlir" 4 10)
+                  z <- Std.addf y y
+                  Std.return [z]
+      MLIR.withContext \ctx -> do
+        MLIR.registerAllDialects ctx
+        nativeOp <- fromAST ctx (mempty, mempty) m
+        MLIR.verifyOperation nativeOp >>= (`shouldBe` True)
+        MLIR.showOperationWithLocation nativeOp >>= (`shouldBe` BS.intercalate "\n" [
+            "#loc0 = loc(unknown)"
+          , "module  {"
+          , "  func @f_loc(%arg0: f32 loc(unknown)) -> f32 {"
+          , "    %0 = addf %arg0, %arg0 : f32 loc(#loc0)"
+          , "    %1 = addf %0, %0 : f32 loc(#loc1)"
+          , "    return %1 : f32 loc(#loc1)"
+          , "  } loc(#loc0)"
+          , "} loc(#loc0)"
+          , "#loc1 = loc(\"file.mlir\":4:10)"
+          , ""])
 
 
 main :: IO ()

--- a/test/MLIR/BuilderSpec.hs
+++ b/test/MLIR/BuilderSpec.hs
@@ -83,7 +83,7 @@ spec = do
                 buildSimpleFunction "f_loc" [f32] NoAttrs do
                   x <- blockArgument f32
                   y <- Std.addf x x
-                  setLocation (FileLocation "file.mlir" 4 10)
+                  setDefaultLocation (FileLocation "file.mlir" 4 10)
                   z <- Std.addf y y
                   Std.return [z]
       MLIR.withContext \ctx -> do


### PR DESCRIPTION
Provides setting the location so that operations built would reuse set location. Similar to ImplicitLocBuilder with the exception that if a not-Unknown location is set, the set location is retained.