### PR TITLE
Add cmake file to build library dep

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,22 +46,22 @@ jobs:
     - name: Ccache for C++ compilation
       uses: hendrikmuhs/ccache-action@4687d037e4d7cf725512d9b819137a3af34d39b3
 
-    - name: Install dependencies (Haskell)
-      run: |
-        stack build --test --only-dependencies
-
     - name: Install dependencies (LLVM & MLIR)
       run: |
         export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
-        cmake -S llvm_src/llvm -B llvm_src/build -DLLVM_CCACHE_BUILD=ON -DLLVM_ENABLE_PROJECTS=mlir \
-          -DLLVM_TARGETS_TO_BUILD="host" -DLLVM_BUILD_LLVM_DYLIB=ON -DCMAKE_BUILD_TYPE=Release \
-          -DLLVM_BUILD_EXAMPLES=OFF -DCMAKE_INSTALL_PREFIX=$HOME/mlir_shared
-        cd llvm_src/build && ninja -j4 install
+        cmake -B llvm_src/build -DLLVM_CCACHE_BUILD=ON \
+          -DLLVM_BUILD_LLVM_DYLIB=ON -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_INSTALL_PREFIX=$HOME/mlir_shared
+        cd llvm_src/build && ninja -j4 install llvm_src/llvm/install
         echo "$HOME/mlir_shared/bin" >> $GITHUB_PATH
       env:
         CC: clang
         CXX: clang++
         CMAKE_GENERATOR: Ninja
+
+    - name: Install dependencies (Haskell)
+      run: |
+        stack build --test --only-dependencies
 
     - name: Build mlir-hs
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,95 @@
+# Copyright 2021 Google LLC. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.13.4)
+
+project(mlir_hs C CXX)
+
+# Some niceties.
+find_program(CCACHE_PROGRAM ccache)
+if(CCACHE_PROGRAM)
+  set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCACHE_PROGRAM}")
+endif()
+
+# CMake settings.
+set(BUILD_SHARED_LIBS OFF CACHE BOOL "We are actually building a static mondo-lib")
+set(CMAKE_PLATFORM_NO_VERSIONED_SONAME ON CACHE BOOL "Python soname linked libraries are bad")
+set(CMAKE_VISIBILITY_INLINES_HIDDEN ON CACHE BOOL "Hide inlines")
+
+# Required LLVM settings.
+set(LLVM_ENABLE_PROJECTS mlir CACHE STRING "LLVM projects")
+set(LLVM_ENABLE_Z3_SOLVER OFF CACHE BOOL "Disable Z3")
+set(LLVM_ENABLE_ZLIB OFF CACHE BOOL "Disable ZLIB")
+set(LLVM_TARGETS_TO_BUILD "host" CACHE STRING "Only build for the host")
+set(LLVM_INCLUDE_EXAMPLES OFF CACHE BOOL "Disable examples")
+# TODO: MLIR is a "tool"
+set(LLVM_INCLUDE_TOOLS ON CACHE BOOL "Disable tools")
+set(LLVM_INCLUDE_TESTS ON CACHE BOOL "Disable tests")
+
+# Required MLIR settings.
+set(MLIR_BINDINGS_PYTHON_LOCK_VERSION OFF CACHE BOOL "Disable linking against libpython")
+
+# LLVM configuration.
+# Expected that LLVM is in/symlinked in to llvm_src.
+set(LLVM_SRC_RELATIVE_DIR "llvm_src" CACHE STRING "Relative path to LLVM source")
+add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/${LLVM_SRC_RELATIVE_DIR}/llvm" EXCLUDE_FROM_ALL)
+
+set(_haskell_mlir_install_prefix "haskell_package")
+set(public_api_libs
+  MLIRCAPIConversion
+  MLIRCAPIDebug
+  MLIRCEXECUTIONENGINE
+  MLIRCAPIIR
+  MLIRCAPIRegistration
+  MLIRCAPITransforms
+
+  # Dialects
+  MLIRCAPIAsync
+  MLIRCAPIGPU
+  MLIRCAPILinalg
+  MLIRCAPILLVM
+  MLIRCAPIShape
+  MLIRCAPISparseTensor
+  MLIRCAPIStandard
+  MLIRCAPISCF
+  MLIRCAPITensor
+)
+
+foreach(lib ${public_api_libs})
+  if(XCODE)
+    # Xcode doesn't support object libraries, so we have to trick it into
+    # linking the static libraries instead.
+    list(APPEND _DEPS "-force_load" ${lib})
+  else()
+    list(APPEND _OBJECTS $<TARGET_OBJECTS:obj.${lib}>)
+  endif()
+  # Accumulate transitive deps of each exported lib into _DEPS.
+  list(APPEND _DEPS  $<TARGET_PROPERTY:${lib},LINK_LIBRARIES>)
+endforeach()
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/${LLVM_SRC_RELATIVE_DIR}/llvm/cmake/modules")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/${LLVM_SRC_RELATIVE_DIR}/mlir/cmake/modules")
+include(AddLLVM)
+include(AddMLIR)
+
+add_mlir_library(MLIRHaskell
+  PARTIAL_SOURCES_INTENDED
+  SHARED
+  ${_OBJECTS}
+  EXCLUDE_FROM_LIBMLIR
+  LINK_LIBS
+  ${_DEPS}
+  LINK_COMPONENTS
+  Support
+)

--- a/README.md
+++ b/README.md
@@ -26,24 +26,20 @@ You should be able to get them from your favorite package manager.
   1. Clone the latest LLVM code (or use `git pull` if you cloned it before)
      ```bash
      git clone https://github.com/llvm/llvm-project
-     cd llvm-project
      ```
 
   2. Create a temporary build directory
      ```bash
-     mkdir build && cd build
+     mkdir llvm-project/build
      ```
 
   3. Configure the build using CMake. Remember to replace `$PREFIX` with the directory
      where you want MLIR to be installed. See [LLVM documentation](https://llvm.org/docs/CMake.html)
      for extended explanation and other potentially interesting build flags.
      ```bash
-     cmake ../llvm                         \
+     cmake -B llvm-project/build           \
        -G Ninja                            \ # Use the Ninja build system
-       -DLLVM_ENABLE_PROJECTS=mlir         \ # Build MLIR
-       -DCMAKE_INSTALL_PREFIX=$PREFIX      \ # Install prefix
-       -DLLVM_BUILD_LLVM_DYLIB=ON          \ # Build the dynamic library
-       -DLLVM_BUILD_EXAMPLES=OFF             # Save some time
+       -DCMAKE_INSTALL_PREFIX=$PREFIX        # Install prefix
      ```
      For development purposes we additionally recommend using
      `-DCMAKE_BUILD_TYPE=RelWithDebInfo -DLLVM_ENABLE_ASSERTIONS=ON`
@@ -52,7 +48,7 @@ You should be able to get them from your favorite package manager.
   4. Build and install MLIR. Note that it uses the installation prefix specified
      in the previous step.
      ```bash
-     ninja install
+     cd llvm-project/build && ninja install llvm-project/llvm/install
      ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ suite can be executed using `stack test`.
 The instructions below assume that you have `cmake` and `ninja` installed.
 You should be able to get them from your favorite package manager.
 
-  1. Clone the latest LLVM code (or use `git pull` if you cloned it before)
+  1. Clone the latest LLVM code (or use `git pull` if you cloned it before) into the root of this repository
      ```bash
      git clone https://github.com/llvm/llvm-project
      ```

--- a/mlir-hs.cabal
+++ b/mlir-hs.cabal
@@ -84,7 +84,7 @@ library
     , bytestring
     , transformers
   extra-libraries:
-    MLIRPublicAPI
+    MLIRHaskell
 
 test-suite spec
   import: defaults


### PR DESCRIPTION
Until a public API is reintroduced, build a local C library target.