### PR TITLE
Addressing warning reported by stack install

### DIFF
--- a/mlir-hs.cabal
+++ b/mlir-hs.cabal
@@ -74,6 +74,15 @@ library
     , MLIR.Native.ExecutionEngine
     , MLIR.Native.FFI
     , MLIR.Native.Pass
+  other-modules:
+      MLIR.AST.Dialect.Generated.LLVM
+    , MLIR.AST.Dialect.Generated.Linalg
+    , MLIR.AST.Dialect.Generated.LinalgStructured
+    , MLIR.AST.Dialect.Generated.Shape
+    , MLIR.AST.Dialect.Generated.Std
+    , MLIR.AST.Dialect.Generated.Tensor
+    , MLIR.AST.Dialect.Generated.Vector
+    , MLIR.AST.Dialect.Generated.X86Vector
   build-depends:
       base >=4.7 && <5
     , inline-c


### PR DESCRIPTION
Mark the modules as other-modules as they are exposed via installed modules.