### PR TITLE
Add NamedLoc

### DIFF
--- a/src/MLIR/AST.hs
+++ b/src/MLIR/AST.hs
@@ -104,7 +104,7 @@ instance Eq Type where
 data Location =
     UnknownLocation
   | FileLocation { locPath :: BS.ByteString, locLine :: UInt, locColumn :: UInt }
-  | NameLocation { name :: BS.ByteString, childLoc :: Location }
+  | NameLocation { locName :: BS.ByteString, locChild :: Location }
   -- TODO(jpienaar): Add support C API side and implement these
   | CallSiteLocation
   | FusedLocation

--- a/src/MLIR/Native.hs
+++ b/src/MLIR/Native.hs
@@ -33,6 +33,7 @@ module MLIR.Native (
     -- * Location
     Location,
     getFileLineColLocation,
+    getNameLocation,
     getUnknownLocation,
     -- * Operation
     Operation,
@@ -145,6 +146,14 @@ getFileLineColLocation ctx (StringRef sPtr len) line col  =
       (MlirStringRef){$(char* sPtr), $(size_t len)},
       $(unsigned int line),
       $(unsigned int col)) } |]
+
+getNameLocation :: Context -> StringRef -> Location -> IO Location
+getNameLocation ctx (StringRef sPtr len) childLoc =
+  [C.exp| MlirLocation {
+    mlirLocationNameGet(
+      $(MlirContext ctx),
+      (MlirStringRef){$(char* sPtr), $(size_t len)},
+      $(MlirLocation childLoc)) } |]
 
 -- TODO(apaszke): No destructor for locations?
 

--- a/test/MLIR/NativeSpec.hs
+++ b/test/MLIR/NativeSpec.hs
@@ -87,6 +87,15 @@ spec = do
         MLIR.destroyModule m
         str `shouldBe` "module  {\n} loc(#loc)\n#loc = loc(\"test.cc\":21:45)\n"
 
+    it "Can create an empty module with name location" $ \ctx -> do
+      MLIR.withStringRef "WhatIamCalled" $ \nameRef -> do
+        childLoc <- MLIR.getUnknownLocation ctx
+        loc <- MLIR.getNameLocation ctx nameRef childLoc
+        m <- MLIR.createEmptyModule loc
+        str <- (MLIR.moduleAsOperation >=> MLIR.showOperationWithLocation) m
+        MLIR.destroyModule m
+        str `shouldBe` "module  {\n} loc(#loc)\n#loc = loc(\"WhatIamCalled\")\n"
+
   describe "Evaluation engine" $ beforeAll prepareContext $ do
     it "Can evaluate the example module" $ \ctx -> do
       m <- liftM fromJust $


### PR DESCRIPTION
Add NamedLoc given C API addition to create NamedLoc. This just adds the basic support without the specialized case where childLoc is optional (e.g., UnknownLocation).