### PR TITLE
Add FusedLoc

### DIFF
--- a/src/MLIR/AST.hs
+++ b/src/MLIR/AST.hs
@@ -240,14 +240,11 @@ instance FromAST Location Native.Location where
           where cline = fromIntegral line
                 ccol = fromIntegral col
     FusedLocation locLocations locMetadata -> do
-      metadata <- case (locMetadata) of
+      metadata <- case locMetadata of
         -- TODO: Consider factoring out to convenience function.
         Nothing -> [C.exp| MlirAttribute { mlirAttributeGetNull() } |]
         Just l -> fromAST ctx env l
       evalContT $ do
-        -- TODO: This limits the creation of FusedLocation to via AST, this is
-        -- contrary to the other Location which have getters in the Native.hs.
-        -- Revise this to make this more uniform.
         (numLocs, locs) <- packFromAST ctx env locLocations
         liftIO $ [C.exp| MlirLocation {
           mlirLocationFusedGet($(MlirContext ctx),

--- a/test/MLIR/NativeSpec.hs
+++ b/test/MLIR/NativeSpec.hs
@@ -14,7 +14,7 @@
 
 module MLIR.NativeSpec where
 
-import Test.Hspec
+import Test.Hspec hiding (shouldContain)
 
 import Text.RawString.QQ
 
@@ -51,8 +51,8 @@ prepareContext = do
 
 -- Helper matcher as shouldContain requires the same type both sides and here
 -- we are predominantly checking if a BS contains some String.
-bsShouldContain :: BS.ByteString -> BS.ByteString -> Expectation
-bsShouldContain str sub = str `shouldSatisfy` BS.isInfixOf sub
+shouldContain :: BS.ByteString -> BS.ByteString -> Expectation
+shouldContain str sub = str `shouldSatisfy` BS.isInfixOf sub
 
 spec :: Spec
 spec = do
@@ -90,16 +90,15 @@ spec = do
         m <- MLIR.createEmptyModule loc
         str <- (MLIR.moduleAsOperation >=> MLIR.showOperationWithLocation) m
         MLIR.destroyModule m
-        str `bsShouldContain` "loc(\"test.cc\":21:45)"
+        str `shouldContain` "loc(\"test.cc\":21:45)"
 
     it "Can create an empty module with name location" $ \ctx -> do
       MLIR.withStringRef "WhatIamCalled" $ \nameRef -> do
-        -- childLoc <- MLIR.getUnknownLocation ctx
         loc <- MLIR.getNameLocation ctx nameRef =<< MLIR.getUnknownLocation ctx
         m <- MLIR.createEmptyModule loc
         str <- (MLIR.moduleAsOperation >=> MLIR.showOperationWithLocation) m
         MLIR.destroyModule m
-        str `bsShouldContain` "loc(\"WhatIamCalled\")"
+        str `shouldContain` "loc(\"WhatIamCalled\")"
 
   describe "Evaluation engine" $ beforeAll prepareContext $ do
     it "Can evaluate the example module" $ \ctx -> do


### PR DESCRIPTION
Add FusedLoc which takes an array of Locations and an optional metadata
attribute. Native lowering for FusedLoc is only via fromAST rather than
having a dedicated getter in Native as the other Locations have (this is
not the first such instance in fromAST though).