### PR TITLE
Update AST and tests after C API change

### DIFF
--- a/test/MLIR/ASTSpec.hs
+++ b/test/MLIR/ASTSpec.hs
@@ -167,7 +167,7 @@ spec = do
       let v64Ty = VectorType [64] Float32Type
       let v64refTy = MemRefType { memrefTypeShape = []
                                 , memrefTypeElement = v64Ty
-                                , memrefTypeAffineMaps = []
+                                , memrefTypeLayout = Nothing
                                 , memrefTypeMemorySpace = Nothing }
       let m = ModuleOp $ Block "0" [] [
                 Do $ emitted $ FuncOp UnknownLocation "matmul8x8x8" (FunctionType [v64refTy, v64refTy, v64refTy] []) $ Region [
@@ -197,7 +197,7 @@ spec = do
 
     it "Can translate matmul via vector.contract" $ do
       let v8x8Ty = VectorType [8, 8] Float32Type
-      let v8x8RefTy = MemRefType [] v8x8Ty [] Nothing
+      let v8x8RefTy = MemRefType [] v8x8Ty Nothing Nothing
       let m = ModuleOp $ Block "0" [] [
                 Do $ emitted $ FuncOp UnknownLocation "matmul8x8x8" (FunctionType [v8x8RefTy, v8x8RefTy, v8x8RefTy] []) $ Region [
                   Block "0" [("arg0", v8x8RefTy), ("arg1", v8x8RefTy), ("arg2", v8x8RefTy)]

--- a/test/MLIR/Test/Generators.hs
+++ b/test/MLIR/Test/Generators.hs
@@ -101,7 +101,7 @@ instance Arbitrary Type where
       leafGenerators = scalarTypeGenerators ++
         [ MemRefType <$> arbitrary
                      <*> arbitraryScalarType
-                     <*> frequency [(9, pure []     ), (1, arbitrary)]
+                     <*> frequency [(9, pure Nothing), (1, arbitrary)]
                      <*> frequency [(9, pure Nothing), (1, arbitrary)]
         , pure NoneType
         , OpaqueType <$> arbitrary <*> arbitrary


### PR DESCRIPTION
There was an upstream change that modified the memref type to replace a
list of affine expressions specifying the layout with an attribute.