### PR TITLE
[TableGen] sanitize builder names, add if-keyword, fix opRegions formatter

### DIFF
--- a/tblgen/hs-generators.cc
+++ b/tblgen/hs-generators.cc
@@ -249,7 +249,7 @@ const std::string sanitizeName(llvm::StringRef name, llvm::Optional<int> idx = l
   static const llvm::StringSet<>* kReservedNames = new llvm::StringSet<>{
       // TODO(apaszke): Add more keywords
       // Haskell keywords
-      "in", "data",
+      "in", "data", "if"
   };
   if (name.empty()) {
     assert(idx);
@@ -497,7 +497,7 @@ llvm::Optional<std::string> buildOperation(
           , opLocation = {1}
           , opResultTypes = Explicit {2}
           , opOperands = {3}
-          , opRegions = [{4:$[ ]}]
+          , opRegions = [{4:$[ , ]}]
           , opSuccessors = []
           , opAttributes = ({5}{6}{7:$[ ]}){8}
           })";
@@ -556,7 +556,7 @@ void emitBuilderMethod(mlir::tblgen::Operator& op,
     prologue = "";
   }
 
-  std::string builder_name = legalizeBuilderName(stripDialect(op.getOperationName()));
+  std::string builder_name = sanitizeName(legalizeBuilderName(stripDialect(op.getOperationName())));
 
   std::vector<std::string> builder_arg_types;
 


### PR DESCRIPTION
Fixes #32

The `opRegions` formatter was also missing a comma separator in its list, this is included too. 

- [X ] Tests pass
- [X ] Appropriate changes to README are included in PR