### PR TITLE
Add DenseArrayAttr type

### DIFF
--- a/src/MLIR/AST/Dialect/ControlFlow.hs
+++ b/src/MLIR/AST/Dialect/ControlFlow.hs
@@ -49,7 +49,7 @@ cond_br cond trueBlock trueArgs falseBlock falseArgs = do
     , opRegions = []
     , opSuccessors = [trueBlock, falseBlock]
     , opAttributes = namedAttribute "operand_segment_sizes" $
-                       DenseElementsAttr (VectorType [3] $ IntegerType Unsigned 32) $
+                       DenseArrayAttr $
                          DenseUInt32 $ listArray (0 :: Int, 2) $ fromIntegral <$> [1, length trueArgs, length falseArgs]
     }
   terminateBlock

--- a/src/MLIR/AST/PatternUtil.hs
+++ b/src/MLIR/AST/PatternUtil.hs
@@ -13,7 +13,8 @@
 -- limitations under the License.
 
 module MLIR.AST.PatternUtil
-  ( pattern I64ArrayAttr
+  ( pattern I32ArrayAttr
+  , pattern I64ArrayAttr
   , pattern AffineMapArrayAttr
   , DummyIx
   ) where
@@ -23,6 +24,16 @@ import Data.Array
 
 import MLIR.AST
 import qualified MLIR.AST.Dialect.Affine as Affine
+
+unwrapI32ArrayAttr :: Attribute -> Maybe [Int]
+unwrapI32ArrayAttr (ArrayAttr vals) = for vals \case
+  IntegerAttr (IntegerType Signed 32) v -> Just v
+  _                                     -> Nothing
+unwrapI32ArrayAttr _ = Nothing
+
+pattern I32ArrayAttr :: [Int] -> Attribute
+pattern I32ArrayAttr vals <- (unwrapI32ArrayAttr -> Just vals)
+  where I32ArrayAttr vals = ArrayAttr $ fmap (IntegerAttr (IntegerType Signed 32)) vals
 
 unwrapI64ArrayAttr :: Attribute -> Maybe [Int]
 unwrapI64ArrayAttr (ArrayAttr vals) = for vals \case


### PR DESCRIPTION
DenseArrayAttr's unsigned/signed variants are still being discussed,
mapping all to the signless for now.

Change the generator to add suffic for most args to avoid shadowing
warnings (Shape dialect has an op that has the same name as an attribute
of another op which results in failure).

Also flip cond.br to use it to fix test.