### PR TITLE
Add a textually represented Attribute variant

### DIFF
--- a/src/MLIR/AST.hs
+++ b/src/MLIR/AST.hs
@@ -130,17 +130,19 @@ data Block = Block {
 data Region = Region [Block]
 
 data Attribute =
-    ArrayAttr      [Attribute]
-  | DictionaryAttr (M.Map Name Attribute)
-  | FloatAttr      Type Double
-  | IntegerAttr    Type Int
-  | BoolAttr       Bool
-  | StringAttr     BS.ByteString
-  | TypeAttr       Type
-  | AffineMapAttr  Affine.Map
+    ArrayAttr         [Attribute]
+  | DictionaryAttr    (M.Map Name Attribute)
+  | FloatAttr         Type Double
+  | IntegerAttr       Type Int
+  | BoolAttr          Bool
+  | StringAttr        BS.ByteString
+  | TypeAttr          Type
+  | AffineMapAttr     Affine.Map
   | UnitAttr
-  | DenseArrayAttr DenseElements
+  | DenseArrayAttr    DenseElements
   | DenseElementsAttr Type DenseElements
+  -- Represents Attribute textually represented.
+  | TextuallyReprAttr BS.ByteString
   deriving Eq
   -- TODO(apaszke): (Flat) SymbolRef, IntegerSet, Opaque
 
@@ -450,6 +452,11 @@ instance FromAST Attribute Native.Attribute where
       Native.withStringRef value \(Native.StringRef ptr len) ->
         [C.exp| MlirAttribute {
           mlirStringAttrGet($(MlirContext ctx), (MlirStringRef){$(char* ptr), $(size_t len)})
+        } |]
+    TextuallyReprAttr value ->
+      Native.withStringRef value \(Native.StringRef ptr len) ->
+        [C.exp| MlirAttribute {
+          mlirAttributeParseGet($(MlirContext ctx), (MlirStringRef){$(char* ptr), $(size_t len)})
         } |]
     TypeAttr ty -> do
       nativeType <- fromAST ctx env ty

--- a/src/MLIR/AST.hs
+++ b/src/MLIR/AST.hs
@@ -142,7 +142,7 @@ data Attribute =
   | DenseArrayAttr    DenseElements
   | DenseElementsAttr Type DenseElements
   -- Represents Attribute textually represented.
-  | TextuallyReprAttr BS.ByteString
+  | AsmTextAttr BS.ByteString
   deriving Eq
   -- TODO(apaszke): (Flat) SymbolRef, IntegerSet, Opaque
 
@@ -453,7 +453,7 @@ instance FromAST Attribute Native.Attribute where
         [C.exp| MlirAttribute {
           mlirStringAttrGet($(MlirContext ctx), (MlirStringRef){$(char* ptr), $(size_t len)})
         } |]
-    TextuallyReprAttr value ->
+    AsmTextAttr value ->
       Native.withStringRef value \(Native.StringRef ptr len) ->
         [C.exp| MlirAttribute {
           mlirAttributeParseGet($(MlirContext ctx), (MlirStringRef){$(char* ptr), $(size_t len)})

--- a/src/MLIR/AST/Dialect/Vector.hs
+++ b/src/MLIR/AST/Dialect/Vector.hs
@@ -36,13 +36,13 @@ itersFromAttribute :: Attribute -> Maybe [IteratorType]
 itersFromAttribute attr = case attr of
   ArrayAttr subAttrs -> traverse iterFromString subAttrs
   _                  -> Nothing
-  where iterFromString (TextuallyReprAttr "#vector.iterator_type<parallel>")  = Just Parallel
-        iterFromString (TextuallyReprAttr "#vector.iterator_type<reduction>") = Just Reduction
+  where iterFromString (AsmTextAttr "#vector.iterator_type<parallel>")  = Just Parallel
+        iterFromString (AsmTextAttr "#vector.iterator_type<reduction>") = Just Reduction
         iterFromString _                        = Nothing
 
 pattern IteratorAttrs :: [IteratorType] -> Attribute
 pattern IteratorAttrs iterTypes <- (itersFromAttribute -> Just iterTypes)
-  where IteratorAttrs iterTypes = ArrayAttr $ fmap (TextuallyReprAttr . showIterator) iterTypes
+  where IteratorAttrs iterTypes = ArrayAttr $ fmap (AsmTextAttr . showIterator) iterTypes
 
 pattern ContractAttrs :: Affine.Map -> Affine.Map -> Affine.Map -> [IteratorType] -> NamedAttributes
 pattern ContractAttrs lhsMap rhsMap accMap iterTypes <-

--- a/src/MLIR/AST/Dialect/Vector.hs
+++ b/src/MLIR/AST/Dialect/Vector.hs
@@ -29,20 +29,20 @@ import qualified MLIR.AST.Dialect.Affine as Affine
 data IteratorType = Parallel | Reduction
 
 showIterator :: IteratorType -> BS.ByteString
-showIterator Parallel  = "parallel"
-showIterator Reduction = "reduction"
+showIterator Parallel  = "#vector.iterator_type<parallel>"
+showIterator Reduction = "#vector.iterator_type<reduction>"
 
 itersFromAttribute :: Attribute -> Maybe [IteratorType]
 itersFromAttribute attr = case attr of
   ArrayAttr subAttrs -> traverse iterFromString subAttrs
   _                  -> Nothing
-  where iterFromString (StringAttr "parallel")  = Just Parallel
-        iterFromString (StringAttr "reduction") = Just Reduction
+  where iterFromString (TextuallyReprAttr "#vector.iterator_type<parallel>")  = Just Parallel
+        iterFromString (TextuallyReprAttr "#vector.iterator_type<reduction>") = Just Reduction
         iterFromString _                        = Nothing
 
 pattern IteratorAttrs :: [IteratorType] -> Attribute
 pattern IteratorAttrs iterTypes <- (itersFromAttribute -> Just iterTypes)
-  where IteratorAttrs iterTypes = ArrayAttr $ fmap (StringAttr . showIterator) iterTypes
+  where IteratorAttrs iterTypes = ArrayAttr $ fmap (TextuallyReprAttr . showIterator) iterTypes
 
 pattern ContractAttrs :: Affine.Map -> Affine.Map -> Affine.Map -> [IteratorType] -> NamedAttributes
 pattern ContractAttrs lhsMap rhsMap accMap iterTypes <-

--- a/src/MLIR/Native.hs
+++ b/src/MLIR/Native.hs
@@ -192,7 +192,7 @@ showOperationWithLocation :: Operation -> IO BS.ByteString
 showOperationWithLocation op = showSomething \ctx ->
   [C.block| void {
     MlirOpPrintingFlags flags = mlirOpPrintingFlagsCreate();
-    mlirOpPrintingFlagsEnableDebugInfo(flags, /*prettyForm=*/false);
+    mlirOpPrintingFlagsEnableDebugInfo(flags, /*enable=*/true, /*prettyForm=*/false);
     mlirOperationPrintWithFlags($(MlirOperation op), flags,
                                 HaskellMlirStringCallback, $(void* ctx));
     mlirOpPrintingFlagsDestroy(flags);

--- a/test/MLIR/ASTSpec.hs
+++ b/test/MLIR/ASTSpec.hs
@@ -219,7 +219,7 @@ spec = do
               ]
       shouldImplementMatmul m
       m `shouldShowAs` [r|
-        #map0 = affine_map<(d0, d1, d2) -> (d0, d2)>
+        #map = affine_map<(d0, d1, d2) -> (d0, d2)>
         #map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
         #map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
         module {
@@ -227,7 +227,7 @@ spec = do
             %0 = memref.load %arg0[] : memref<vector<8x8xf32>>
             %1 = memref.load %arg1[] : memref<vector<8x8xf32>>
             %2 = memref.load %arg2[] : memref<vector<8x8xf32>>
-            %3 = vector.contract {indexing_maps = [#map0, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction"], kind = #vector.kind<add>} %0, %1, %2 : vector<8x8xf32>, vector<8x8xf32> into vector<8x8xf32>
+            %3 = vector.contract {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction"], kind = #vector.kind<add>} %0, %1, %2 : vector<8x8xf32>, vector<8x8xf32> into vector<8x8xf32>
             memref.store %3, %arg2[] : memref<vector<8x8xf32>>
             return
           }

--- a/test/MLIR/ASTSpec.hs
+++ b/test/MLIR/ASTSpec.hs
@@ -159,12 +159,11 @@ spec = do
         , opAttributes = NoAttrs
         }
       m `shouldShowWithLocationAs` [r|
-        #loc = loc(unknown)
-        #loc1 = loc("first")
-        #loc2 = loc("last")
         module {
-        } loc(#loc3)
-        #loc3 = loc(fused["first", "last"])|]
+        } loc(#loc2)
+        #loc = loc("first")
+        #loc1 = loc("last")
+        #loc2 = loc(fused[#loc, #loc1])|]
 
     it "Can construct a matmul via vector.matrix_multiply" $ do
       let v64Ty = VectorType [64] Float32Type


### PR DESCRIPTION
Not all Attributes are exposed in C API, enable specifying using the pure textual format too.

Flip Vector iterator_types to use this.