### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+    types: [ opened, synchronize ]
   schedule:
     # Always regenerate once every 4 hour
     - cron:  '15 */4 * * *'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.1
 
     - name: Setup Haskell Stack
+      id: setup-haskell
       uses: haskell-actions/setup@f7d8a55550ba6c8e4fdba2f1e56e14f595218dd9 # v2.5.1
       with:
         enable-stack: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
     - name: Checkout the repository
-      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.1
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
     - name: Setup Haskell Stack
       id: setup-haskell
@@ -50,14 +50,14 @@ jobs:
       uses: llvm/actions/install-ninja@55d844821959226fab4911f96f37071c1d4c3268
 
     - name: Clone LLVM repo
-      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         repository: llvm/llvm-project
         ref: 'main'
         path: 'llvm-project'
 
     - name: Ccache for C++ compilation
-      uses: hendrikmuhs/ccache-action@4687d037e4d7cf725512d9b819137a3af34d39b3
+      uses: hendrikmuhs/ccache-action@6d1841ec156c39a52b1b23a810da917ab98da1f4 # v1.2.10
 
     - name: Install dependencies (LLVM & MLIR)
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,23 +16,30 @@ jobs:
 
     steps:
     - name: Checkout the repository
-      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.1
 
     - name: Setup Haskell Stack
-      uses: actions/setup-haskell@v1
+      uses: haskell-actions/setup@f7d8a55550ba6c8e4fdba2f1e56e14f595218dd9 # v2.5.1
       with:
         enable-stack: true
         stack-no-global: true
         stack-version: 'latest'
 
-    - name: Cache
-      uses: actions/cache@70655ec8323daeeaa7ef06d7c56e1b9191396cbe
+    - name: Cache .stack-work
+      uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
       with:
-        path: |
-          ~/.stack
-          $GITHUB_WORKSPACE/.stack-work
-        key: ${{ runner.os }}-${{ hashFiles('**/*.cabal', 'stack*.yaml') }}
-        restore-keys: ${{ runner.os }}-
+        path: .stack-work
+        key: stack-work-${{ runner.os }}-${{ hashFiles('stack.yaml', '**/*.cabal') }}-${{ hashFiles('src/*', 'tblgen/*', 'test/*') }}
+        restore-keys: |
+          stack-work-${{ runner.os }}-${{ hashFiles('stack.yaml', '**/*.cabal') }}-
+          stack-work-${{ runner.os }}-
+
+    - name: Cache ~/.stack
+      uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
+      with:
+        path: ${{ steps.setup-haskell.outputs.stack-root }}
+        key: stack-root-${{ runner.os }}-${{ hashFiles('stack.yaml', '**/*.cabal') }}
+        restore-keys: stack-root-${{ runner.os }}-
 
     - name: Install zstd
       run: sudo apt install libzstd-dev
@@ -66,14 +73,14 @@ jobs:
 
     - name: Install dependencies (Haskell)
       run: |
-        stack build --test --only-dependencies
+        stack build --only-dependencies --test --no-run-tests
 
     - name: Build mlir-hs
       run: |
         export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/mlir_shared/lib
-        stack build --test --ghc-options "-Wall -Werror -fforce-recomp"
+        stack build --ghc-options "-Wall -Werror -fforce-recomp" --test --no-run-tests
 
     - name: Run mlir-hs tests
       run: |
         export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/mlir_shared/lib
-        stack test
+        stack test --ghc-options "-Wall -Werror -fforce-recomp"

--- a/src/MLIR/AST/Dialect/LLVM.hs
+++ b/src/MLIR/AST/Dialect/LLVM.hs
@@ -38,8 +38,7 @@ import qualified MLIR.Native.FFI    as Native
 C.context $ C.baseCtx <> Native.mlirCtx
 C.include "mlir-c/Dialect/LLVM.h"
 
-data Type = PointerType AST.Type
-          | ArrayType Int AST.Type
+data Type = ArrayType Int AST.Type
           | VoidType
           | LiteralStructType [AST.Type]
           -- TODO(apaszke): Structures, functions, vectors, etc.
@@ -47,7 +46,6 @@ data Type = PointerType AST.Type
 
 instance AST.FromAST Type Native.Type where
   fromAST ctx env ty = case ty of
-    PointerType t -> [C.exp| MlirType { mlirLLVMPointerTypeGet($(MlirContext ctx), 0) } |]
     ArrayType size t -> do
       nt <- AST.fromAST ctx env t
       let nsize = fromIntegral size
@@ -65,10 +63,6 @@ castLLVMType :: AST.Type -> Maybe Type
 castLLVMType ty = case ty of
   AST.DialectType dty -> cast dty
   _                   -> Nothing
-
-pattern Ptr :: AST.Type -> AST.Type
-pattern Ptr t <- (castLLVMType -> Just (PointerType t))
-  where Ptr t = AST.DialectType (PointerType t)
 
 pattern Array :: Int -> AST.Type -> AST.Type
 pattern Array n t <- (castLLVMType -> Just (ArrayType n t))

--- a/src/MLIR/AST/Dialect/LLVM.hs
+++ b/src/MLIR/AST/Dialect/LLVM.hs
@@ -47,9 +47,7 @@ data Type = PointerType AST.Type
 
 instance AST.FromAST Type Native.Type where
   fromAST ctx env ty = case ty of
-    PointerType t -> do
-      nt <- AST.fromAST ctx env t
-      [C.exp| MlirType { mlirLLVMPointerTypeGet($(MlirType nt), 0) } |]
+    PointerType t -> [C.exp| MlirType { mlirLLVMPointerTypeGet($(MlirContext ctx), 0) } |]
     ArrayType size t -> do
       nt <- AST.fromAST ctx env t
       let nsize = fromIntegral size

--- a/src/MLIR/AST/Dialect/LLVM.hs
+++ b/src/MLIR/AST/Dialect/LLVM.hs
@@ -15,7 +15,6 @@
 module MLIR.AST.Dialect.LLVM (
   -- * Types
     Type(..)
-  , pattern Ptr
   , pattern Array
   , pattern Void
   , pattern LiteralStruct


### PR DESCRIPTION
- [x] Split Haskell cache into 2 components, one for dependencies, one for code
- [x] Reduce recompilation between tests and main library
- [x] Don't run test twice
- [x] Remove `PointerType` as it was removed from upstream LLVM
- [x] Add tag to all reusable actions so that tools like Dependabot could keep them up to date
- [x] Only run CI on PRs when they are opened or updated

I'm thinking we might not need the `--fforce-recomp` flag, but for that I'll have to look deeper. For now, https://github.com/mihaimaruseac/mlir-hs/actions/runs/6765678946/job/18385656313 is a green run of the actions, the large time is spent in compiling LLVM, Haskell compilation is quite fast.