### PR TITLE
Fix X86 dialect name case in Setup.hs

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -139,7 +139,7 @@ main = defaultMainWithHooks simpleUserHooks
             , ("LinalgStructured", "mlir/Dialect/Linalg/IR/LinalgStructuredOps.td", ["-dialect-name", "LinalgStructured"])
             , ("Tensor"          , "mlir/Dialect/Tensor/IR/TensorOps.td", ["-strip-prefix", "Tensor_"])
             , ("UB"              , "mlir/Dialect/UB/IR/UBOps.td", ["-dialect-name", "UB"])
-            , ("X86"             , "mlir/Dialect/X86/X86.td", ["-dialect-name", "x86"])
+            , ("X86"             , "mlir/Dialect/X86/X86.td", ["-dialect-name", "X86"])
             ]
       ensureDirectory "src/MLIR/AST/Dialect/Generated"
       generatedModules <- forM dialects $ \(dialect, tdPath, opts) -> do


### PR DESCRIPTION
The dialect-name flag for X86 was incorrectly set to "x86". Changed to "X86" to match the dialect name and ensure correct generation.

Fixes CI